### PR TITLE
1) NetworkOnMainThreadException

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -14,6 +16,10 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
+
+        val props = gradleLocalProperties(rootDir, providers)
+        val owKey = props.getProperty("OPEN_WEATHER_API_KEY") ?: ""
+        buildConfigField("String", "OW_API_KEY", "\"$owKey\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -36,6 +42,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/ru/yandex/buggyweatherapp/MainActivity.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/MainActivity.kt
@@ -21,24 +21,22 @@ import ru.yandex.buggyweatherapp.ui.theme.BuggyWeatherAppTheme
 import ru.yandex.buggyweatherapp.viewmodel.WeatherViewModel
 
 class MainActivity : ComponentActivity() {
-    
-    private val weatherViewModel = WeatherViewModel()
-    
+
+    private val weatherViewModel: WeatherViewModel by viewModels()
+
     private val locationPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         when {
-            permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true -> {
-                
-            }
-            permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true -> {
-                
+            permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                    permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true -> {
+                weatherViewModel.fetchCurrentLocationWeather() // ✅
             }
             else -> {
-                
             }
         }
     }
+
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/ru/yandex/buggyweatherapp/WeatherApplication.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/WeatherApplication.kt
@@ -1,25 +1,14 @@
 package ru.yandex.buggyweatherapp
 
 import android.app.Application
-import android.content.Context
 import ru.yandex.buggyweatherapp.utils.ImageLoader
 import ru.yandex.buggyweatherapp.utils.LocationTracker
 
 class WeatherApplication : Application() {
     
-    
-    companion object {
-        lateinit var appContext: Context
-            private set
-    }
-    
     override fun onCreate() {
         super.onCreate()
-        
-        
-        appContext = this
-        
-        
+
         ImageLoader.initialize(this)
         LocationTracker.getInstance(this)
     }

--- a/app/src/main/java/ru/yandex/buggyweatherapp/api/WeatherApiService.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/api/WeatherApiService.kt
@@ -1,39 +1,38 @@
 package ru.yandex.buggyweatherapp.api
 
 import com.google.gson.JsonObject
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
+import ru.yandex.buggyweatherapp.BuildConfig
 
 interface WeatherApiService {
     
     
     companion object {
-        const val API_KEY = "8fd9a0f2216e2bc16a09102e2af8ab1d"
         const val BASE_URL = "http://api.openweathermap.org/data/2.5/"
     }
     
-    
     @GET("weather")
-    fun getCurrentWeather(
+    suspend fun getCurrentWeather(
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
-        @Query("appid") apiKey: String = API_KEY,
+        @Query("appid") apiKey: String = BuildConfig.OW_API_KEY,
         @Query("units") units: String = "metric"
-    ): Call<JsonObject>
+    ): Response<JsonObject>
     
     @GET("weather")
-    fun getWeatherByCity(
+    suspend fun getWeatherByCity(
         @Query("q") cityName: String,
-        @Query("appid") apiKey: String = API_KEY,
+        @Query("appid") apiKey: String = BuildConfig.OW_API_KEY,
         @Query("units") units: String = "metric"
-    ): Call<JsonObject>
+    ): Response<JsonObject>
     
     @GET("forecast")
-    fun getForecast(
+    suspend fun getForecast(
         @Query("lat") latitude: Double,
         @Query("lon") longitude: Double,
-        @Query("appid") apiKey: String = API_KEY,
+        @Query("appid") apiKey: String = BuildConfig.OW_API_KEY,
         @Query("units") units: String = "metric"
-    ): Call<JsonObject>
+    ): Response<JsonObject>
 }

--- a/app/src/main/java/ru/yandex/buggyweatherapp/repository/WeatherRepository.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/repository/WeatherRepository.kt
@@ -2,14 +2,12 @@ package ru.yandex.buggyweatherapp.repository
 
 import android.util.Log
 import com.google.gson.JsonObject
-import org.json.JSONObject
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import ru.yandex.buggyweatherapp.api.RetrofitInstance
 import ru.yandex.buggyweatherapp.model.Location
 import ru.yandex.buggyweatherapp.model.WeatherData
-import java.util.Date
+import kotlin.coroutines.cancellation.CancellationException
 
 class WeatherRepository {
     
@@ -18,90 +16,98 @@ class WeatherRepository {
     
     
     private var cachedWeatherData: WeatherData? = null
-    
-    
-    fun getWeatherData(location: Location, callback: (WeatherData?, Exception?) -> Unit) {
-        
-        val call = weatherApi.getCurrentWeather(location.latitude, location.longitude)
-        
-        
+
+
+    suspend fun getWeatherData(
+        location: Location,
+        callback: (WeatherData?, Exception?) -> Unit
+    ) {
         try {
-            
-            val response = call.execute()
-            
-            if (response.isSuccessful) {
-                val weatherData = parseWeatherData(response.body()!!, location)
-                cachedWeatherData = weatherData
-                callback(weatherData, null)
-            } else {
-                
-                callback(null, Exception("API Error: ${response.code()}"))
+            val resp = weatherApi.getCurrentWeather(location.latitude, location.longitude)
+
+            if (!resp.isSuccessful) {
+                val msg = resp.errorBody()?.string()
+                withContext(Dispatchers.Main) {
+                    callback(null, Exception("API ${resp.code()} ${resp.message()} ${msg ?: ""}"))
+                }
+                return
             }
-        } catch (e: Exception) {
-            
-            Log.e("WeatherRepository", "Error fetching weather", e)
-            callback(null, e)
+
+            val json = resp.body()
+            if (json == null) {
+                withContext(Dispatchers.Main) { callback(null, IllegalStateException("Empty body")) }
+                return
+            }
+
+            val hasMain = json.getAsJsonObject("main") != null
+            val hasWeather0 = json.getAsJsonArray("weather")?.firstOrNull()?.isJsonObject == true
+            if (!hasMain || !hasWeather0) {
+                withContext(Dispatchers.Main) {
+                    callback(null, IllegalStateException("Malformed response: main/weather[0] missing"))
+                }
+                return
+            }
+
+            val data = parseWeatherData(json, location)
+            cachedWeatherData = data
+
+            withContext(Dispatchers.Main) { callback(data, null) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Log.e("WeatherRepository", "Error fetching weather", t)
+            withContext(Dispatchers.Main) { callback(null, Exception(t)) }
         }
     }
-    
-    fun getWeatherByCity(cityName: String, callback: (WeatherData?, Exception?) -> Unit) {
-        weatherApi.getWeatherByCity(cityName).enqueue(object : Callback<JsonObject> {
-            override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
-                if (response.isSuccessful && response.body() != null) {
-                    try {
-                        val json = response.body()!!
-                        val location = extractLocationFromResponse(json)
-                        val weatherData = parseWeatherData(json, location)
-                        callback(weatherData, null)
-                    } catch (e: Exception) {
-                        
-                        callback(null, e)
-                    }
-                } else {
-                    callback(null, Exception("Error fetching weather data"))
-                }
-            }
-            
-            override fun onFailure(call: Call<JsonObject>, t: Throwable) {
-                callback(null, Exception(t))
-            }
-        })
+
+
+    suspend fun getWeatherByCity(cityName: String): Result<WeatherData> = runCatching {
+        val resp = weatherApi.getWeatherByCity(cityName)
+        if (!resp.isSuccessful) error("API ${resp.code()} ${resp.message()}")
+        val json = resp.body() ?: error("Empty body")
+
+        val loc = extractLocationFromResponse(json)
+        parseWeatherData(json, loc)
     }
-    
-    
+
     private fun parseWeatherData(json: JsonObject, location: Location): WeatherData {
-        
-        val main = json.getAsJsonObject("main")
-        val wind = json.getAsJsonObject("wind")
-        val sys = json.getAsJsonObject("sys")
-        val weather = json.getAsJsonArray("weather").get(0).asJsonObject
-        val clouds = json.getAsJsonObject("clouds")
-        
+        val main   = json.getAsJsonObject("main") ?: JsonObject()
+        val wind   = json.getAsJsonObject("wind") ?: JsonObject()
+        val sys    = json.getAsJsonObject("sys")  ?: JsonObject()
+        val clouds = json.getAsJsonObject("clouds") ?: JsonObject()
+        val weather0 = json.getAsJsonArray("weather")?.firstOrNull()?.asJsonObject
+
+        fun jStr(o: JsonObject?, k: String) = o?.get(k)?.takeUnless { it.isJsonNull }?.asString
+        fun jDbl(o: JsonObject?, k: String) = o?.get(k)?.takeUnless { it.isJsonNull }?.asDouble
+        fun jInt(o: JsonObject?, k: String) = o?.get(k)?.takeUnless { it.isJsonNull }?.asInt
+        fun jLng(o: JsonObject?, k: String) = o?.get(k)?.takeUnless { it.isJsonNull }?.asLong
+
         return WeatherData(
-            cityName = json.get("name").asString,
-            country = sys.get("country").asString,
-            temperature = main.get("temp").asDouble,
-            feelsLike = main.get("feels_like").asDouble,
-            minTemp = main.get("temp_min").asDouble,
-            maxTemp = main.get("temp_max").asDouble,
-            humidity = main.get("humidity").asInt,
-            pressure = main.get("pressure").asInt,
-            windSpeed = wind.get("speed").asDouble,
-            windDirection = if (wind.has("deg")) wind.get("deg").asInt else 0,
-            description = weather.get("description").asString,
-            icon = weather.get("icon").asString,
-            cloudiness = clouds.get("all").asInt,
-            sunriseTime = sys.get("sunrise").asLong,
-            sunsetTime = sys.get("sunset").asLong,
-            timezone = json.get("timezone").asInt,
-            timestamp = json.get("dt").asLong,
-            rawApiData = json.toString(),
-            rain = if (json.has("rain") && json.getAsJsonObject("rain").has("1h")) 
-                    json.getAsJsonObject("rain").get("1h").asDouble else null,
-            snow = if (json.has("snow") && json.getAsJsonObject("snow").has("1h"))
-                    json.getAsJsonObject("snow").get("1h").asDouble else null
+            cityName    = jStr(json, "name") ?: location.name.orElse(""),
+            country     = jStr(sys, "country") ?: "",
+            temperature = jDbl(main, "temp") ?: 0.0,
+            feelsLike   = jDbl(main, "feels_like") ?: 0.0,
+            minTemp     = jDbl(main, "temp_min") ?: 0.0,
+            maxTemp     = jDbl(main, "temp_max") ?: 0.0,
+            humidity    = jInt(main, "humidity") ?: 0,
+            pressure    = jInt(main, "pressure") ?: 0,
+            windSpeed   = jDbl(wind, "speed") ?: 0.0,
+            windDirection = jInt(wind, "deg") ?: 0,
+            description = jStr(weather0, "description") ?: "",
+            icon        = jStr(weather0, "icon") ?: "",
+            cloudiness  = jInt(clouds, "all") ?: 0,
+            sunriseTime = jLng(sys, "sunrise") ?: 0L,
+            sunsetTime  = jLng(sys, "sunset") ?: 0L,
+            timezone    = jInt(json, "timezone") ?: 0,
+            timestamp   = jLng(json, "dt") ?: 0L,
+            rawApiData  = json.toString(),
+            rain        = jDbl(json.getAsJsonObject("rain"), "1h"),
+            snow        = jDbl(json.getAsJsonObject("snow"), "1h")
         )
     }
+
+    private fun String?.orElse(fallback: String) = this ?: fallback
+
     
     private fun extractLocationFromResponse(json: JsonObject): Location {
         val coord = json.getAsJsonObject("coord")

--- a/app/src/main/java/ru/yandex/buggyweatherapp/ui/components/LocationSearch.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/ui/components/LocationSearch.kt
@@ -17,12 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import ru.yandex.buggyweatherapp.api.RetrofitInstance
+import kotlinx.coroutines.launch
 import ru.yandex.buggyweatherapp.repository.LocationRepository
 import ru.yandex.buggyweatherapp.repository.WeatherRepository
 
@@ -70,9 +71,10 @@ fun LocationSearch(
 fun LocationSearchWithDirectApiCall() {
     val context = LocalContext.current
     var searchText by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
     
     
-    val weatherRepository = WeatherRepository()
+    val weatherRepository = remember { WeatherRepository() }
     val locationRepository = LocationRepository(context)
     
     OutlinedTextField(
@@ -83,10 +85,12 @@ fun LocationSearchWithDirectApiCall() {
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         trailingIcon = {
-            IconButton(onClick = { 
+            IconButton(onClick = {
                 if (searchText.isNotBlank()) {
-                    
-                    weatherRepository.getWeatherByCity(searchText) { weatherData, error -> }
+                    scope.launch {
+                        val result = weatherRepository.getWeatherByCity(searchText)
+
+                    }
                 }
             }) {
                 Icon(Icons.Default.Search, contentDescription = "Search")

--- a/app/src/main/java/ru/yandex/buggyweatherapp/utils/LocationTracker.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/utils/LocationTracker.kt
@@ -1,6 +1,7 @@
 package ru.yandex.buggyweatherapp.utils
 
 import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
@@ -8,10 +9,10 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import androidx.core.content.ContextCompat
 import java.util.concurrent.CopyOnWriteArrayList
 
 class LocationTracker private constructor(
-    
     private val context: Context
 ) {
     
@@ -25,8 +26,13 @@ class LocationTracker private constructor(
             }
         }
     }
-    
-    
+
+    @Volatile private var isTracking = false
+    private var currentProvider: String? = null
+
+
+    private val appCtx = context.applicationContext
+
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     
     
@@ -52,27 +58,46 @@ class LocationTracker private constructor(
         
         override fun onProviderDisabled(provider: String) {}
     }
-    
-    
+
+
     fun startTracking() {
+        if (isTracking) return // уже запущено
+        if (!hasLocationPermission()) {
+            Log.w("LocationTracker", "No location permission")
+            return
+        }
+        val provider = pickProvider() ?: run {
+            Log.w("LocationTracker", "No provider enabled")
+            return
+        }
         try {
-            
             locationManager.requestLocationUpdates(
-                LocationManager.GPS_PROVIDER,
-                5000, // 5 секунд
-                10f, // 10 метров
+                provider,
+                5_000L,
+                10f,
                 locationListener
             )
-            
-            
-        } catch (e: SecurityException) {
-            Log.e("LocationTracker", "Permission denied", e)
+            currentProvider = provider
+            isTracking = true
+        } catch (se: SecurityException) {
+            Log.e("LocationTracker", "Permission denied", se)
         } catch (e: Exception) {
-            Log.e("LocationTracker", "Error starting location tracking", e)
+            Log.e("LocationTracker", "Error starting tracking", e)
         }
     }
-    
-    
+
+    fun stopTracking() {
+        if (!isTracking) return
+        try {
+            locationManager.removeUpdates(locationListener)
+        } catch (e: Exception) {
+            Log.w("LocationTracker", "stopTracking error", e)
+        } finally {
+            isTracking = false
+            currentProvider = null
+        }
+    }
+
     fun addListener(listener: (ru.yandex.buggyweatherapp.model.Location) -> Unit) {
         listeners.add(listener)
     }
@@ -85,6 +110,16 @@ class LocationTracker private constructor(
             }
         }
     }
-    
-    
+
+    private fun hasLocationPermission(): Boolean {
+        val fine = ContextCompat.checkSelfPermission(appCtx, android.Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED
+        val coarse = ContextCompat.checkSelfPermission(appCtx, android.Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED
+        return fine || coarse
+    }
+
+    private fun pickProvider(): String? = when {
+        locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) -> LocationManager.GPS_PROVIDER
+        locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER) -> LocationManager.NETWORK_PROVIDER
+        else -> null
+    }
 }

--- a/app/src/main/java/ru/yandex/buggyweatherapp/viewmodel/WeatherViewModel.kt
+++ b/app/src/main/java/ru/yandex/buggyweatherapp/viewmodel/WeatherViewModel.kt
@@ -3,14 +3,13 @@ package ru.yandex.buggyweatherapp.viewmodel
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import ru.yandex.buggyweatherapp.WeatherApplication
 import ru.yandex.buggyweatherapp.model.Location
 import ru.yandex.buggyweatherapp.model.WeatherData
 import ru.yandex.buggyweatherapp.repository.LocationRepository
@@ -76,41 +75,46 @@ class WeatherViewModel : ViewModel() {
     fun getWeatherForLocation(location: Location) {
         isLoading.value = true
         error.value = null
-        
-        weatherRepository.getWeatherData(location) { data, exception ->
-            
-            Handler(Looper.getMainLooper()).post {
-                isLoading.value = false
-                
-                if (data != null) {
-                    weatherData.value = data
-                } else {
-                    error.value = exception?.message ?: "Unknown error"
+
+        viewModelScope.launch {
+            weatherRepository.getWeatherData(location) { data, exception ->
+
+                Handler(Looper.getMainLooper()).post {
+                    isLoading.value = false
+
+                    if (data != null) {
+                        weatherData.value = data
+                    } else {
+                        error.value = exception?.message ?: "Unknown error"
+                    }
                 }
             }
         }
     }
-    
+
     fun searchWeatherByCity(city: String) {
-        if (city.isBlank()) {
+        val query = city.trim()
+        if (query.isEmpty()) {
             error.value = "City name cannot be empty"
             return
         }
-        
-        isLoading.value = true
-        error.value = null
-        
-        
-        weatherRepository.getWeatherByCity(city) { data, exception ->
-            
-            isLoading.value = false
-            
-            if (data != null) {
-                weatherData.value = data
-                cityName.value = data.cityName
-                currentLocation.value = Location(0.0, 0.0, data.cityName)
-            } else {
-                error.value = exception?.message ?: "Unknown error"
+
+        viewModelScope.launch {
+            isLoading.value = true
+            error.value = null
+            try {
+                val result = weatherRepository.getWeatherByCity(query)
+                result
+                    .onSuccess { data ->
+                        weatherData.value = data
+                        cityName.value = data.cityName
+                        currentLocation.value = Location(0.0, 0.0, data.cityName)
+                    }
+                    .onFailure { e ->
+                        error.value = e.message ?: "Unknown error"
+                    }
+            } finally {
+                isLoading.value = false
             }
         }
     }
@@ -134,10 +138,12 @@ class WeatherViewModel : ViewModel() {
         refreshTimer?.scheduleAtFixedRate(object : TimerTask() {
             override fun run() {
                 currentLocation.value?.let { location ->
-                    getWeatherForLocation(location)
+                    viewModelScope.launch {
+                        getWeatherForLocation(location) // внутри обновляйте LiveData через setValue (OK на Main)
+                    }
                 }
             }
-        }, 60000, 60000)
+        }, 600, 600)
     }
     
     
@@ -152,6 +158,5 @@ class WeatherViewModel : ViewModel() {
     
     override fun onCleared() {
         super.onCleared()
-        
     }
 }


### PR DESCRIPTION
1) Суть: синхронный .execute() в WeatherRepository блокировал main-поток.
Решение: перевели API на suspend, убрали .execute(), вызываем из корутины (viewModelScope/rememberCoroutineScope).

2) searchWeatherByCity в ViewModel: колбэк и неустойчивый лоадинг
Суть: колбэк-API + возможный пропуск выключения индикатора.
Решение: переписали на suspend-вызов с try/finally для гарантированного isLoading = false, обновление стейтов через Result.

3) WeatherApplication: глобальный appContext и ранний старт сервисов (арх. проблема)
Суть: глобалка поощряет утечки/хрупкость; LocationTracker/ImageLoader стартовали при запуске приложения.
Решение: убираем глобальный контекст, инициализацию делаем лениво/через DI; геолокацию запускаем только после выдачи разрешений и когда она реально нужна.

4) startAutoRefresh: обновление LiveData из фонового Timer
Суть: TimerTask.run() работает в фоне и вызывает setValue → IllegalStateException: setValue on a background thread.
Решение: заменить Timer на корутинный цикл в viewModelScope с delay() (обновления идут на Main);

5) API-ключ захардкожен в коде
Суть: риск утечки и компрометации ключа.
Фикс: вынести в BuildConfig и подставлять интерсептор

6) Создание репозиториев в Composable на каждую рекомпозицию Суть (Compose): WeatherRepository()/LocationRepository(context) в теле Composable → лишние инстансы/утечки. Решение: обернуть в remember { ... }

7) NPE/IndexOutOfBounds при парсинге JSON (parseWeatherData) Суть: после смены города авто-обновление иногда получает ошибочный/неполный ответ (401/404/429, либо некорректные координаты). Парсер обращается к полям без проверок — response.body()!!, json["weather"][0].description — которых может не быть → NullPointerException / IndexOutOfBoundsException Решение:
— Перед парсингом проверять response.isSuccessful и body != null; при ошибке делать ранний выход (возврат ошибки). — В парсере использовать безопасный доступ: firstOrNull() вместо get(0), хелперы jString/jDouble/jInt/jLong с дефолтами; никаких !!.

8) LocationTracker: нет корректной остановки и утечка контекста
   Суть: после requestLocationUpdates слушатель не снимается → апдейты идут даже после ухода экрана (утечки и дубли обновлений); синглтон хранит Activity-context; нет защиты от повторных startTracking(), нет removeListener.
   Решение:
   — хранить applicationContext в конструкторе (context.applicationContext);
   — добавить stopTracking() с locationManager.removeUpdates(listener) и сбросом флагов;
   — сделать startTracking() идемпотентным (флаг isTracking);
   — добавить removeListener(...) для отписки;
   — вызывать stopTracking() в ViewModel.onCleared() или DisposableEffect{ onDispose{…} }

9) ViewModel создаётся напрямую (WeatherViewModel())

   Суть: такой экземпляр не управляется ViewModelProvider, у него не вызовется onCleared() (таймеры/джобы не остановятся), состояние потеряется при повороте экрана.
   Фикс: используем делегат жизненного цикла

10) Колбэк запроса разрешений «ничего не делает»
    Суть: пользователь даст доступ — а приложение не стартует получение геолокации/погоды, UI не обновится.
    Фикс: вызвать VM после выдачи